### PR TITLE
Exosuit Stress Sensor QoL

### DIFF
--- a/src/main/java/vazkii/psi/common/core/handler/PlayerDataHandler.java
+++ b/src/main/java/vazkii/psi/common/core/handler/PlayerDataHandler.java
@@ -179,6 +179,10 @@ public class PlayerDataHandler {
 				if (event.getSource().isFireDamage()) {
 					PsiArmorEvent.post(new PsiArmorEvent(player, PsiArmorEvent.ON_FIRE));
 				}
+				if (player.getHealth() - event.getAmount() <= 0.0) {
+					PsiArmorEvent.post(new PsiArmorEvent(player, PsiArmorEvent.LOW_HP));
+					PlayerDataHandler.get(player).lowHp = true;
+				}
 			}
 		}
 

--- a/src/main/java/vazkii/psi/common/core/handler/PlayerDataHandler.java
+++ b/src/main/java/vazkii/psi/common/core/handler/PlayerDataHandler.java
@@ -179,7 +179,7 @@ public class PlayerDataHandler {
 				if (event.getSource().isFireDamage()) {
 					PsiArmorEvent.post(new PsiArmorEvent(player, PsiArmorEvent.ON_FIRE));
 				}
-				if (player.getHealth() - event.getAmount() <= 0.0) {
+				if (player.getHealth() - event.getAmount() <= 0.0 && !PlayerDataHandler.get(player).lowHp) {
 					PsiArmorEvent.post(new PsiArmorEvent(player, PsiArmorEvent.LOW_HP));
 					PlayerDataHandler.get(player).lowHp = true;
 				}


### PR DESCRIPTION
Currently Stress Sensor will never activate if the blow would immediately reduce the caster from >6 HP to 0.
Perhaps making it able to trigger off the damage event would make it more desirable overall by enabling it to trigger on what would be a lethal blow?
Probably needs further thought but threw this together quickly to test the concept.  