### PR TITLE
Trick: Break Loop shouldn't stop the current cast

### DIFF
--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickBreakLoop.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickBreakLoop.java
@@ -75,8 +75,6 @@ public class PieceTrickBreakLoop extends PieceTrick {
 				PlayerDataHandler.PlayerData data = PlayerDataHandler.get(context.caster);
 				data.stopLoopcast();
 			}
-
-			context.stopped = true;
 		}
 		return null;
 	}


### PR DESCRIPTION
Trick: Break Loop shouldn't imply a Trick: Die. This would allow for more advanced uses of the piece, making it more than something with barely any real use cases.