### PR TITLE
Move SpellHelpers to API

### DIFF
--- a/src/main/java/vazkii/psi/api/spell/SpellHelpers.java
+++ b/src/main/java/vazkii/psi/api/spell/SpellHelpers.java
@@ -6,17 +6,12 @@
  * Psi is Open Source and distributed under the
  * Psi License: https://psi.vazkii.net/license.php
  */
-package vazkii.psi.common.core.helpers;
+package vazkii.psi.api.spell;
 
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 
 import vazkii.psi.api.internal.Vector3;
-import vazkii.psi.api.spell.SpellCompilationException;
-import vazkii.psi.api.spell.SpellContext;
-import vazkii.psi.api.spell.SpellParam;
-import vazkii.psi.api.spell.SpellPiece;
-import vazkii.psi.api.spell.SpellRuntimeException;
 
 public class SpellHelpers {
 

--- a/src/main/java/vazkii/psi/common/spell/operator/block/PieceOperatorBlockComparatorStrength.java
+++ b/src/main/java/vazkii/psi/common/spell/operator/block/PieceOperatorBlockComparatorStrength.java
@@ -18,11 +18,11 @@ import net.minecraft.util.math.BlockPos;
 import vazkii.psi.api.internal.Vector3;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.param.ParamVector;
 import vazkii.psi.api.spell.piece.PieceOperator;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 public class PieceOperatorBlockComparatorStrength extends PieceOperator {
 

--- a/src/main/java/vazkii/psi/common/spell/operator/block/PieceOperatorBlockHardness.java
+++ b/src/main/java/vazkii/psi/common/spell/operator/block/PieceOperatorBlockHardness.java
@@ -14,11 +14,11 @@ import net.minecraft.util.math.BlockPos;
 import vazkii.psi.api.internal.Vector3;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.param.ParamVector;
 import vazkii.psi.api.spell.piece.PieceOperator;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 public class PieceOperatorBlockHardness extends PieceOperator {
 	SpellParam<Vector3> target;

--- a/src/main/java/vazkii/psi/common/spell/operator/block/PieceOperatorBlockLightLevel.java
+++ b/src/main/java/vazkii/psi/common/spell/operator/block/PieceOperatorBlockLightLevel.java
@@ -13,11 +13,11 @@ import net.minecraft.util.math.BlockPos;
 import vazkii.psi.api.internal.Vector3;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.param.ParamVector;
 import vazkii.psi.api.spell.piece.PieceOperator;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 public class PieceOperatorBlockLightLevel extends PieceOperator {
 

--- a/src/main/java/vazkii/psi/common/spell/operator/block/PieceOperatorBlockMiningLevel.java
+++ b/src/main/java/vazkii/psi/common/spell/operator/block/PieceOperatorBlockMiningLevel.java
@@ -14,11 +14,11 @@ import net.minecraft.util.math.BlockPos;
 import vazkii.psi.api.internal.Vector3;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.param.ParamVector;
 import vazkii.psi.api.spell.piece.PieceOperator;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 public class PieceOperatorBlockMiningLevel extends PieceOperator {
 

--- a/src/main/java/vazkii/psi/common/spell/operator/block/PieceOperatorBlockSideSolidity.java
+++ b/src/main/java/vazkii/psi/common/spell/operator/block/PieceOperatorBlockSideSolidity.java
@@ -15,11 +15,11 @@ import net.minecraft.util.math.BlockPos;
 import vazkii.psi.api.internal.Vector3;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.param.ParamVector;
 import vazkii.psi.api.spell.piece.PieceOperator;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 public class PieceOperatorBlockSideSolidity extends PieceOperator {
 	SpellParam<Vector3> axisParam;

--- a/src/main/java/vazkii/psi/common/spell/operator/entity/PieceOperatorClosestToLine.java
+++ b/src/main/java/vazkii/psi/common/spell/operator/entity/PieceOperatorClosestToLine.java
@@ -14,13 +14,13 @@ import net.minecraft.util.math.vector.Vector3d;
 import vazkii.psi.api.internal.Vector3;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.param.ParamEntityListWrapper;
 import vazkii.psi.api.spell.param.ParamVector;
 import vazkii.psi.api.spell.piece.PieceOperator;
 import vazkii.psi.api.spell.wrapper.EntityListWrapper;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 import static vazkii.psi.common.spell.operator.entity.PieceOperatorClosestToPoint.closestToPoint;
 

--- a/src/main/java/vazkii/psi/common/spell/operator/entity/PieceOperatorEntityRaycast.java
+++ b/src/main/java/vazkii/psi/common/spell/operator/entity/PieceOperatorEntityRaycast.java
@@ -17,12 +17,12 @@ import vazkii.psi.api.internal.Vector3;
 import vazkii.psi.api.spell.ISpellImmune;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.param.ParamNumber;
 import vazkii.psi.api.spell.param.ParamVector;
 import vazkii.psi.api.spell.piece.PieceOperator;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 import java.util.Optional;
 import java.util.function.Predicate;

--- a/src/main/java/vazkii/psi/common/spell/operator/vector/PieceOperatorVectorAbsolute.java
+++ b/src/main/java/vazkii/psi/common/spell/operator/vector/PieceOperatorVectorAbsolute.java
@@ -11,11 +11,11 @@ package vazkii.psi.common.spell.operator.vector;
 import vazkii.psi.api.internal.Vector3;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.param.ParamVector;
 import vazkii.psi.api.spell.piece.PieceOperator;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 public class PieceOperatorVectorAbsolute extends PieceOperator {
 

--- a/src/main/java/vazkii/psi/common/spell/operator/vector/PieceOperatorVectorRaycast.java
+++ b/src/main/java/vazkii/psi/common/spell/operator/vector/PieceOperatorVectorRaycast.java
@@ -17,12 +17,12 @@ import net.minecraft.util.math.vector.Vector3d;
 import vazkii.psi.api.internal.Vector3;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.param.ParamNumber;
 import vazkii.psi.api.spell.param.ParamVector;
 import vazkii.psi.api.spell.piece.PieceOperator;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 public class PieceOperatorVectorRaycast extends PieceOperator {
 

--- a/src/main/java/vazkii/psi/common/spell/operator/vector/PieceOperatorVectorRaycastAxis.java
+++ b/src/main/java/vazkii/psi/common/spell/operator/vector/PieceOperatorVectorRaycastAxis.java
@@ -16,12 +16,12 @@ import net.minecraft.util.math.RayTraceResult;
 import vazkii.psi.api.internal.Vector3;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.param.ParamNumber;
 import vazkii.psi.api.spell.param.ParamVector;
 import vazkii.psi.api.spell.piece.PieceOperator;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 public class PieceOperatorVectorRaycastAxis extends PieceOperator {
 

--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickChangeSlot.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickChangeSlot.java
@@ -11,7 +11,6 @@ package vazkii.psi.common.spell.trick;
 import vazkii.psi.api.spell.*;
 import vazkii.psi.api.spell.param.ParamNumber;
 import vazkii.psi.api.spell.piece.PieceTrick;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 public class PieceTrickChangeSlot extends PieceTrick {
 

--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickDetonate.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickDetonate.java
@@ -12,13 +12,13 @@ import vazkii.psi.api.spell.EnumSpellStat;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellCompilationException;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellMetadata;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.detonator.IDetonationHandler;
 import vazkii.psi.api.spell.param.ParamNumber;
 import vazkii.psi.api.spell.piece.PieceTrick;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 import static vazkii.psi.api.spell.SpellContext.MAX_DISTANCE;
 

--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickOvergrow.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickOvergrow.java
@@ -25,12 +25,12 @@ import vazkii.psi.api.spell.EnumSpellStat;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellCompilationException;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellMetadata;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.param.ParamVector;
 import vazkii.psi.api.spell.piece.PieceTrick;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 public class PieceTrickOvergrow extends PieceTrick {
 

--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickParticleTrail.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickParticleTrail.java
@@ -16,13 +16,13 @@ import vazkii.psi.api.spell.EnumSpellStat;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellCompilationException;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellMetadata;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.param.ParamNumber;
 import vazkii.psi.api.spell.param.ParamVector;
 import vazkii.psi.api.spell.piece.PieceTrick;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 import vazkii.psi.common.network.MessageRegister;
 import vazkii.psi.common.network.message.MessageParticleTrail;
 

--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickPlaySound.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickPlaySound.java
@@ -16,6 +16,7 @@ import vazkii.psi.api.internal.Vector3;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellCompilationException;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellMetadata;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
@@ -23,7 +24,6 @@ import vazkii.psi.api.spell.param.ParamNumber;
 import vazkii.psi.api.spell.param.ParamVector;
 import vazkii.psi.api.spell.piece.PieceTrick;
 import vazkii.psi.common.Psi;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 public class PieceTrickPlaySound extends PieceTrick {
 

--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickTorrent.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickTorrent.java
@@ -28,12 +28,12 @@ import vazkii.psi.api.spell.EnumSpellStat;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellCompilationException;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellMetadata;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.param.ParamVector;
 import vazkii.psi.api.spell.piece.PieceTrick;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 import javax.annotation.Nullable;
 

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickMoveBlockSequence.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickMoveBlockSequence.java
@@ -22,13 +22,13 @@ import vazkii.psi.api.spell.EnumSpellStat;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellCompilationException;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellMetadata;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.param.ParamNumber;
 import vazkii.psi.api.spell.param.ParamVector;
 import vazkii.psi.api.spell.piece.PieceTrick;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 import java.util.HashMap;
 import java.util.LinkedHashSet;

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickTill.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickTill.java
@@ -25,12 +25,12 @@ import vazkii.psi.api.spell.EnumSpellStat;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellCompilationException;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellMetadata;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.param.ParamVector;
 import vazkii.psi.api.spell.piece.PieceTrick;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 public class PieceTrickTill extends PieceTrick {
 	SpellParam<Vector3> position;

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickTillSequence.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickTillSequence.java
@@ -16,13 +16,13 @@ import vazkii.psi.api.spell.EnumSpellStat;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellCompilationException;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.spell.SpellHelpers;
 import vazkii.psi.api.spell.SpellMetadata;
 import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.param.ParamNumber;
 import vazkii.psi.api.spell.param.ParamVector;
 import vazkii.psi.api.spell.piece.PieceTrick;
-import vazkii.psi.common.core.helpers.SpellHelpers;
 
 public class PieceTrickTillSequence extends PieceTrick {
 


### PR DESCRIPTION
Most addons have to reimplement SpellHelpers without this change.