### PR TITLE
Fixed Break Block breaking Bedrock and other unbreakable Blocks

### DIFF
--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickBreakBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickBreakBlock.java
@@ -96,7 +96,6 @@ public class PieceTrickBreakBlock extends PieceTrick {
 
 		BlockState blockstate = world.getBlockState(pos);
 		boolean unminable = blockstate.getDestroyProgress(player, world, pos) == 0;
-		unminable = false;
 		if (!world.isClientSide && !unminable && filter.test(blockstate) && !blockstate.isAir()) {
 			ItemStack save = player.getMainHandItem();
 			boolean wasChecking = doingHarvestCheck.get();


### PR DESCRIPTION
Removed line that makes mineable check in break block obsolete
(probably left from debugging)