### PR TITLE
fix: All main advancements unlocking instantly for 1.18

### DIFF
--- a/src/main/resources/data/psi/advancements/main/ebony_assembly_pickup.json
+++ b/src/main/resources/data/psi/advancements/main/ebony_assembly_pickup.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "item": "psi:cad_assembly_ebony_psimetal"
+            "items": ["psi:cad_assembly_ebony_psimetal"]
           }
         ]
       }

--- a/src/main/resources/data/psi/advancements/main/ebony_pickup.json
+++ b/src/main/resources/data/psi/advancements/main/ebony_pickup.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "item": "psi:ebony_substance"
+            "items": ["psi:ebony_substance"]
           }
         ]
       }

--- a/src/main/resources/data/psi/advancements/main/encyclopaedia_psionica.json
+++ b/src/main/resources/data/psi/advancements/main/encyclopaedia_psionica.json
@@ -18,7 +18,7 @@
       "conditions": {
         "items": [
           {
-            "item": "patchouli:guide_book",
+            "items": ["patchouli:guide_book"],
             "nbt": "{\"patchouli:book\": \"psi:encyclopaedia_psionica\"}"
           }
         ]

--- a/src/main/resources/data/psi/advancements/main/gold_assembly_pickup.json
+++ b/src/main/resources/data/psi/advancements/main/gold_assembly_pickup.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "item": "psi:cad_assembly_gold"
+            "items": ["psi:cad_assembly_gold"]
           }
         ]
       }

--- a/src/main/resources/data/psi/advancements/main/iron_cad_pickup.json
+++ b/src/main/resources/data/psi/advancements/main/iron_cad_pickup.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "item": "psi:cad_assembly_iron"
+            "items": ["psi:cad_assembly_iron"]
           }
         ]
       }

--- a/src/main/resources/data/psi/advancements/main/ivory_assembly_pickup.json
+++ b/src/main/resources/data/psi/advancements/main/ivory_assembly_pickup.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "item": "psi:cad_assembly_ivory_psimetal"
+            "items": ["psi:cad_assembly_ivory_psimetal"]
           }
         ]
       }

--- a/src/main/resources/data/psi/advancements/main/ivory_pickup.json
+++ b/src/main/resources/data/psi/advancements/main/ivory_pickup.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "item": "psi:ivory_substance"
+            "items": ["psi:ivory_substance"]
           }
         ]
       }

--- a/src/main/resources/data/psi/advancements/main/psidust.json
+++ b/src/main/resources/data/psi/advancements/main/psidust.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "item": "psi:psidust"
+            "items": ["psi:psidust"]
           }
         ]
       }

--- a/src/main/resources/data/psi/advancements/main/psigem_pickup.json
+++ b/src/main/resources/data/psi/advancements/main/psigem_pickup.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "item": "psi:psigem"
+            "items": ["psi:psigem"]
           }
         ]
       }

--- a/src/main/resources/data/psi/advancements/main/psimetal_assembly_pickup.json
+++ b/src/main/resources/data/psi/advancements/main/psimetal_assembly_pickup.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "item": "psi:cad_assembly_psimetal"
+            "items": ["psi:cad_assembly_psimetal"]
           }
         ]
       }

--- a/src/main/resources/data/psi/advancements/main/psimetal_pickup.json
+++ b/src/main/resources/data/psi/advancements/main/psimetal_pickup.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "item": "psi:psimetal"
+            "items": ["psi:psimetal"]
           }
         ]
       }

--- a/src/main/resources/data/psi/advancements/main/root.json
+++ b/src/main/resources/data/psi/advancements/main/root.json
@@ -19,7 +19,7 @@
       "conditions": {
         "items": [
           {
-            "item": "psi:cad_assembly_iron"
+            "items": ["psi:cad_assembly_iron"]
           }
         ]
       }


### PR DESCRIPTION
Fixes #790 

Minecraft version: **1.18**

Because of an invalid advancement format, all main advancements were unlocked on inventory change.

### Diff

```diff
"conditions": {
  "items": [
    {
-     "item": "minecraft:example_item"
+     "items": ["minecraft:example_item"]
    }
  ]
}
```

### Explanation

In recent versions, the format has changed. The field has been renamed from `item` to `items` and now accepts list of item ids instead of a single item id.