### PR TITLE
fix: Energy bar desync between server and client

### DIFF
--- a/src/main/java/vazkii/psi/common/item/ItemCAD.java
+++ b/src/main/java/vazkii/psi/common/item/ItemCAD.java
@@ -130,6 +130,22 @@ public class ItemCAD extends Item implements ICAD {
 	}
 
 	@Override
+	public @Nullable CompoundTag getShareTag(ItemStack stack) {
+		CompoundTag nbt = stack.getOrCreateTag();
+		stack.getCapability(PsiAPI.CAD_DATA_CAPABILITY).ifPresent(data -> nbt.put("CapabilityData", data.serializeNBT()));
+		return nbt;
+	}
+
+	@Override
+	public void readShareTag(ItemStack stack, @Nullable CompoundTag nbt) {
+		super.readShareTag(stack, nbt);
+
+		if (nbt != null) {
+			stack.getCapability(PsiAPI.CAD_DATA_CAPABILITY).ifPresent(data -> data.deserializeNBT(nbt.getCompound("CapabilityData")));
+		}
+	}
+
+	@Override
 	public void inventoryTick(ItemStack stack, Level world, Entity entityIn, int itemSlot, boolean isSelected) {
 		CompoundTag compound = stack.getOrCreateTag();
 


### PR DESCRIPTION
Fixes #794 

Minecraft version: **1.18**

Adds cad data synchronization through item capability data. Cherry-picked from the [1.19.2 branch](https://github.com/VazkiiMods/Psi/tree/1.19.2).