### PR TITLE
Collected fixes

### DIFF
--- a/src/main/java/vazkii/psi/api/spell/Spell.java
+++ b/src/main/java/vazkii/psi/api/spell/Spell.java
@@ -87,6 +87,7 @@ public final class Spell {
 					spell.grid.gridData[i][j] = piece.copyFromSpell(spell);
 					spell.grid.gridData[i][j].x = i;
 					spell.grid.gridData[i][j].y = j;
+					spell.grid.gridData[i][j].isInGrid = piece.isInGrid;
 				}
 			}
 		}

--- a/src/main/java/vazkii/psi/api/spell/SpellGrid.java
+++ b/src/main/java/vazkii/psi/api/spell/SpellGrid.java
@@ -68,6 +68,7 @@ public final class SpellGrid {
 		for(var piece : spellList) {
 			piece.piece.x = piece.x;
 			piece.piece.y = piece.y;
+			piece.piece.isInGrid = true;
 			grid.gridData[piece.x][piece.y] = piece.piece;
 		}
 		grid.empty = spellList.isEmpty();

--- a/src/main/java/vazkii/psi/api/spell/SpellPiece.java
+++ b/src/main/java/vazkii/psi/api/spell/SpellPiece.java
@@ -353,7 +353,11 @@ public abstract class SpellPiece {
 	 * Sets a {@link StatLabel}'s value.
 	 */
 	public void setStatLabel(EnumSpellStat type, StatLabel descriptor) {
-		statLabels.put(type, descriptor);
+		if(descriptor == null) {
+			statLabels.remove(type);
+		} else {
+			statLabels.put(type, descriptor);
+		}
 	}
 
 	/**

--- a/src/main/java/vazkii/psi/client/render/entity/RenderSpellCircle.java
+++ b/src/main/java/vazkii/psi/client/render/entity/RenderSpellCircle.java
@@ -139,10 +139,11 @@ public class RenderSpellCircle extends EntityRenderer<EntitySpellCircle> {
 		ItemStack colorizer = entity.getEntityData().get(EntitySpellCircle.COLORIZER_DATA);
 		int color = Psi.proxy.getColorForColorizer(colorizer);
 		float alive = entity.getTimeAlive() + partialTicks;
-		float scale = Math.min(entity.getEntityData().get(EntitySpellCircle.SCALE), alive / EntitySpellCircle.CAST_DELAY);
+		float entityScale = entity.getEntityData().get(EntitySpellCircle.SCALE);
+		float scale = Math.min(entityScale, alive / EntitySpellCircle.CAST_DELAY);
 		int lifetime = entity.getEntityData().get(EntitySpellCircle.LIFETIME);
 		if(alive > lifetime - EntitySpellCircle.CAST_DELAY) {
-			scale = 1F - Math.min(1F, Math.max(0, alive - (lifetime - EntitySpellCircle.CAST_DELAY)) / EntitySpellCircle.CAST_DELAY);
+			scale = entityScale - Math.min(entityScale, Math.max(0, alive - (lifetime - EntitySpellCircle.CAST_DELAY)) / EntitySpellCircle.CAST_DELAY);
 		}
 
 		renderSpellCircle(alive, scale, 1, entity.getEntityData().get(EntitySpellCircle.DIRECTION_X), entity.getEntityData().get(EntitySpellCircle.DIRECTION_Y), entity.getEntityData().get(EntitySpellCircle.DIRECTION_Z), color, ms, buffers);

--- a/src/main/java/vazkii/psi/client/render/entity/RenderSpellCircle.java
+++ b/src/main/java/vazkii/psi/client/render/entity/RenderSpellCircle.java
@@ -67,9 +67,6 @@ public class RenderSpellCircle extends EntityRenderer<EntitySpellCircle> {
 		Vec3 axis = normal.cross(direction);
 		double dot = normal.dot(direction);
 
-		// Rotate the model so that it's normal matches the normal
-		ms.mulPose(Axis.YP.rotationDegrees(90));
-
 		// Very small threshold to see if it's parallel or not.
 		if(axis.length() < 1e-6) {
 			// If it's parallel but the dot product is negative we flip it.

--- a/src/main/java/vazkii/psi/common/entity/EntitySpellCircle.java
+++ b/src/main/java/vazkii/psi/common/entity/EntitySpellCircle.java
@@ -13,9 +13,8 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -24,6 +23,8 @@ import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import org.joml.Vector3d;
+import org.joml.Vector3f;
 import vazkii.psi.api.internal.PsiRenderHelper;
 import vazkii.psi.api.spell.ISpellAcceptor;
 import vazkii.psi.api.spell.ISpellImmune;
@@ -197,11 +198,24 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 			float g = PsiRenderHelper.g(colorVal) / 255F;
 			float b = PsiRenderHelper.b(colorVal) / 255F;
 			for(int i = 0; i < 5; i++) {
-				double x = getX() + (Math.random() - 0.5) * getBbWidth();
-				double y = getY();
-				double z = getZ() + (Math.random() - 0.5) * getBbWidth();
+				Vector3d direction = new Vector3d(entityData.get(DIRECTION_X), entityData.get(DIRECTION_Y), entityData.get(DIRECTION_Z)).normalize();
+				// rotate to match RenderSpellCircle
+				direction.rotateAxis(Mth.HALF_PI, 0, 1, 0);
+				Vector3d localX, localZ;
+				if(direction.equals(0, 1, 0) || direction.equals(0, -1, 0)) {
+					localX = new Vector3d(1, 0, 0);
+					localZ = new Vector3d(0, 0, 1);
+				} else {
+					localX = direction.cross(0, -1, 0, new Vector3d()).normalize();
+					localZ = direction.cross(localX, new Vector3d()).normalize();
+				}
 				float grav = -0.15F - (float) Math.random() * 0.03F;
-				Psi.proxy.sparkleFX(x, y, z, r, g, b, grav, 0.25F, 15);
+				direction.mul(-grav);
+				Vector3d position = new Vector3d()
+						.add(localX.mul(((Math.random() - 0.5) * getBbWidth() * getScale())))
+						.add(localZ.mul(((Math.random() - 0.5) * getBbWidth() * getScale())))
+						.add(getX(), getY(), getZ());
+				Psi.proxy.sparkleFX(position.x, position.y, position.z, r, g, b, (float)direction.x, (float)direction.y, (float)direction.z, 0.25F, 15);
 			}
 		}
 
@@ -227,6 +241,14 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 		entityData.set(DIRECTION_Z, (float) direction.z);
 	}
 
+	public @NotNull EntityDimensions getDimensions(@NotNull Pose pose){
+		return super.getDimensions(pose).scale(getScale());
+	}
+	
+	public float getScale() {
+		return entityData.get(SCALE);
+	}
+	
 	public void setScale(float scale) {
 		entityData.set(SCALE, scale);
 	}

--- a/src/main/java/vazkii/psi/common/entity/EntitySpellCircle.java
+++ b/src/main/java/vazkii/psi/common/entity/EntitySpellCircle.java
@@ -199,8 +199,6 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 			float b = PsiRenderHelper.b(colorVal) / 255F;
 			for(int i = 0; i < 5; i++) {
 				Vector3d direction = new Vector3d(entityData.get(DIRECTION_X), entityData.get(DIRECTION_Y), entityData.get(DIRECTION_Z)).normalize();
-				// rotate to match RenderSpellCircle
-				direction.rotateAxis(Mth.HALF_PI, 0, 1, 0);
 				Vector3d localX, localZ;
 				if(direction.equals(0, 1, 0) || direction.equals(0, -1, 0)) {
 					localX = new Vector3d(1, 0, 0);

--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickBreakLoop.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickBreakLoop.java
@@ -25,6 +25,8 @@ public class PieceTrickBreakLoop extends PieceTrick {
 
 	public PieceTrickBreakLoop(Spell spell) {
 		super(spell);
+		setStatLabel(EnumSpellStat.COMPLEXITY, null);
+		setStatLabel(EnumSpellStat.PROJECTION, null);
 	}
 
 	@Override

--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickChangeSlot.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickChangeSlot.java
@@ -18,6 +18,7 @@ public class PieceTrickChangeSlot extends PieceTrick {
 
 	public PieceTrickChangeSlot(Spell spell) {
 		super(spell);
+		setStatLabel(EnumSpellStat.COMPLEXITY, new StatLabel(2));
 	}
 
 	@Override

--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickDebug.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickDebug.java
@@ -24,6 +24,8 @@ public class PieceTrickDebug extends PieceTrick {
 
 	public PieceTrickDebug(Spell spell) {
 		super(spell);
+		setStatLabel(EnumSpellStat.COMPLEXITY, null);
+		setStatLabel(EnumSpellStat.PROJECTION, null);
 	}
 
 	@Override

--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickDebugSpamless.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickDebugSpamless.java
@@ -27,6 +27,8 @@ public class PieceTrickDebugSpamless extends PieceTrick {
 
 	public PieceTrickDebugSpamless(Spell spell) {
 		super(spell);
+		setStatLabel(EnumSpellStat.COMPLEXITY, null);
+		setStatLabel(EnumSpellStat.PROJECTION, null);
 	}
 
 	@Override

--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickDelay.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickDelay.java
@@ -18,8 +18,9 @@ public class PieceTrickDelay extends PieceTrick {
 
 	public PieceTrickDelay(Spell spell) {
 		super(spell);
-		setStatLabel(EnumSpellStat.COMPLEXITY, new StatLabel(2));
+		setStatLabel(EnumSpellStat.COMPLEXITY, new StatLabel(1));
 		setStatLabel(EnumSpellStat.POTENCY, new StatLabel(SpellParam.GENERIC_NAME_TIME, true));
+		setStatLabel(EnumSpellStat.PROJECTION, null);
 	}
 
 	@Override

--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickDie.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickDie.java
@@ -19,6 +19,7 @@ public class PieceTrickDie extends PieceTrick {
 	public PieceTrickDie(Spell spell) {
 		super(spell);
 		setStatLabel(EnumSpellStat.COMPLEXITY, new StatLabel(1));
+		setStatLabel(EnumSpellStat.PROJECTION, null);
 	}
 
 	@Override

--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickEvaluate.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickEvaluate.java
@@ -8,10 +8,7 @@
  */
 package vazkii.psi.common.spell.trick;
 
-import vazkii.psi.api.spell.Spell;
-import vazkii.psi.api.spell.SpellContext;
-import vazkii.psi.api.spell.SpellMetadata;
-import vazkii.psi.api.spell.SpellParam;
+import vazkii.psi.api.spell.*;
 import vazkii.psi.api.spell.param.ParamAny;
 import vazkii.psi.api.spell.piece.PieceTrick;
 
@@ -21,6 +18,8 @@ public class PieceTrickEvaluate extends PieceTrick {
 
 	public PieceTrickEvaluate(Spell spell) {
 		super(spell);
+		setStatLabel(EnumSpellStat.COMPLEXITY, null);
+		setStatLabel(EnumSpellStat.PROJECTION, null);
 	}
 
 	@Override

--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickSaveVector.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickSaveVector.java
@@ -29,6 +29,7 @@ public class PieceTrickSaveVector extends PieceTrick {
 		super(spell);
 		setStatLabel(EnumSpellStat.COMPLEXITY, new StatLabel(2));
 		setStatLabel(EnumSpellStat.POTENCY, new StatLabel(SpellParam.GENERIC_NAME_NUMBER, true).mul(8));
+		setStatLabel(EnumSpellStat.PROJECTION, null);
 	}
 
 	@Override

--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickSwitchTargetSlot.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickSwitchTargetSlot.java
@@ -19,7 +19,8 @@ public class PieceTrickSwitchTargetSlot extends PieceTrick {
 
 	public PieceTrickSwitchTargetSlot(Spell spell) {
 		super(spell);
-		setStatLabel(EnumSpellStat.COMPLEXITY, new StatLabel(2));
+		setStatLabel(EnumSpellStat.COMPLEXITY, new StatLabel(1));
+		setStatLabel(EnumSpellStat.PROJECTION, null);
 	}
 
 	@Override

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickConjureBlockSequence.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickConjureBlockSequence.java
@@ -30,8 +30,8 @@ public class PieceTrickConjureBlockSequence extends PieceTrick {
 
 	public PieceTrickConjureBlockSequence(Spell spell) {
 		super(spell);
-		setStatLabel(EnumSpellStat.POTENCY, new StatLabel(SpellParam.GENERIC_NAME_MAX, true).add(15));
-		setStatLabel(EnumSpellStat.COST, new StatLabel(SpellParam.GENERIC_NAME_MAX, true).sub(1).parenthesize().mul(14).sub(24));
+		setStatLabel(EnumSpellStat.POTENCY, new StatLabel(SpellParam.GENERIC_NAME_MAX, true).mul(15));
+		setStatLabel(EnumSpellStat.COST, new StatLabel(SpellParam.GENERIC_NAME_MAX, true).sub(1).parenthesize().mul(14).add(24));
 	}
 
 	@Override

--- a/src/main/java/vazkii/psi/common/spell/trick/entity/PieceTrickConjureCircle.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/entity/PieceTrickConjureCircle.java
@@ -22,6 +22,7 @@ public class PieceTrickConjureCircle extends PieceTrick {
 
 	public PieceTrickConjureCircle(Spell spell) {
 		super(spell);
+		setStatLabel(EnumSpellStat.POTENCY, new StatLabel(SpellParam.GENERIC_NAME_RADIUS, true).mul(SpellParam.GENERIC_NAME_TIME, true).parenthesize().div(100));
 	}
 
 	@Override

--- a/src/main/java/vazkii/psi/common/spell/trick/entity/PieceTrickMassBlink.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/entity/PieceTrickMassBlink.java
@@ -23,8 +23,8 @@ public class PieceTrickMassBlink extends PieceTrick {
 
 	public PieceTrickMassBlink(Spell spell) {
 		super(spell);
-		setStatLabel(EnumSpellStat.POTENCY, new StatLabel(SpellParam.GENERIC_NAME_DISTANCE, true).abs().mul(90));
-		setStatLabel(EnumSpellStat.COST, new StatLabel(SpellParam.GENERIC_NAME_DISTANCE, true).abs().mul(105).max(1));
+		setStatLabel(EnumSpellStat.POTENCY, new StatLabel(SpellParam.GENERIC_NAME_DISTANCE, true).abs().mul(80));
+		setStatLabel(EnumSpellStat.COST, new StatLabel(SpellParam.GENERIC_NAME_DISTANCE, true).abs().mul(100));
 	}
 
 	@Override

--- a/src/main/java/vazkii/psi/common/spell/trick/potion/PieceTrickPotionBase.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/potion/PieceTrickPotionBase.java
@@ -27,8 +27,13 @@ public abstract class PieceTrickPotionBase extends PieceTrick {
 
 	public PieceTrickPotionBase(Spell spell) {
 		super(spell);
-		setStatLabel(EnumSpellStat.POTENCY, new StatLabel(SpellParam.GENERIC_NAME_TIME, true).mul(SpellParam.GENERIC_NAME_POWER, true).square().mul(5));
-		setStatLabel(EnumSpellStat.COST, new StatLabel(SpellParam.GENERIC_NAME_TIME, true).mul(SpellParam.GENERIC_NAME_POWER, true).square().mul(5).square());
+		if(hasPower()) {
+			setStatLabel(EnumSpellStat.POTENCY, new StatLabel(SpellParam.GENERIC_NAME_TIME, true).mul(new StatLabel(SpellParam.GENERIC_NAME_POWER, true).square().mul(5).add(20)));
+			setStatLabel(EnumSpellStat.COST, new StatLabel(SpellParam.GENERIC_NAME_TIME, true).mul(new StatLabel(SpellParam.GENERIC_NAME_POWER, true).square().mul(25).add(40)));
+		} else {
+			setStatLabel(EnumSpellStat.POTENCY, new StatLabel(SpellParam.GENERIC_NAME_TIME, true).mul(5).add(20));
+			setStatLabel(EnumSpellStat.COST, new StatLabel(SpellParam.GENERIC_NAME_TIME, true).mul(25).add(40));
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Fixes:
- Many incorrect cost tooltips on spell pieces, especially on control flow tricks and all status effect tricks
  - The new tooltips match the code, but in some places the code seems incorrect (e.g. change inventory slot)
- Connections not showing between spell pieces on a flash ring after reopening the GUI (`isInGrid` wasn't getting persisted by the spell codec code, or set by the spell grid codec)
- Visual issues with scaled spell circles (jumping size when disappearing, generating particles in the wrong bounding box) and rotated spell circles (particles not rotating to face the circle's direction)
  - This removes a 90deg rotation that used to be applied to rotated spell circles that points them away from their facing direction, so it does change behaviour slightly; but this rotation is hard to account for in spells and I'd be surprised if many spells used them (but still notable)